### PR TITLE
🔧 update (ui): fix wifi label overflow

### DIFF
--- a/src/ui/screens/ui_settings.c
+++ b/src/ui/screens/ui_settings.c
@@ -192,6 +192,7 @@ void ui_settings_screen_init(void)
     lv_obj_set_y(ui_wifi_status, 19);
     lv_obj_add_flag(ui_wifi_status, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_wifi_status, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
+    lv_obj_clear_flag(ui_wifi_status, LV_OBJ_FLAG_OVERFLOW_VISIBLE); /// Keep marquee text inside the card
     lv_obj_set_style_radius(ui_wifi_status, 18, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_opa(ui_wifi_status, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_border_width(ui_wifi_status, 0, LV_PART_MAIN | LV_STATE_DEFAULT);

--- a/src/ui/screens/ui_wifi.c
+++ b/src/ui/screens/ui_wifi.c
@@ -738,11 +738,10 @@ void ui_wifi_screen_init(void)
     ui_wifi_key_a_home = lv_label_create(ui_wifi);
     lv_obj_set_width(ui_wifi_key_a_home, LV_SIZE_CONTENT);
     lv_obj_set_height(ui_wifi_key_a_home, LV_SIZE_CONTENT);
-    lv_obj_set_x(ui_wifi_key_a_home, 195);
-    lv_obj_set_y(ui_wifi_key_a_home, 210);
     lv_label_set_text(ui_wifi_key_a_home, "Connect");
     lv_obj_set_style_text_color(ui_wifi_key_a_home, lv_color_hex(0x000000), LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_font(ui_wifi_key_a_home, &ui_font_name_14, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_align_to(ui_wifi_key_a_home, ui_wifi_key_a_bg, LV_ALIGN_CENTER, 0, 0);
 
     ui_wifi_key_b_back = lv_label_create(ui_wifi);
     lv_obj_set_width(ui_wifi_key_b_back, LV_SIZE_CONTENT);


### PR DESCRIPTION
This pull request makes small improvements to the UI layout and behavior for the WiFi and Settings screens. The changes focus on better alignment and visual containment of UI elements.

UI layout and containment improvements:

* In `ui_settings_screen_init` (`src/ui/screens/ui_settings.c`), the WiFi status label now has the `LV_OBJ_FLAG_OVERFLOW_VISIBLE` flag cleared to ensure that marquee text stays inside its card, improving visual containment.
* In `ui_wifi_screen_init` (`src/ui/screens/ui_wifi.c`), the "Connect" label (`ui_wifi_key_a_home`) is now aligned to the center of its background using `lv_obj_align_to` instead of hardcoded x/y coordinates, making the layout more robust and easier to maintain.