### PR TITLE
Truncate long SSIDs instead of letting them wrap out of the WLAN row

### DIFF
--- a/src/ui/screens/ui_wifi.c
+++ b/src/ui/screens/ui_wifi.c
@@ -447,6 +447,11 @@ static void _wifi_build_list(void)
         lv_obj_t * ssid_lbl = lv_label_create(row);
         lv_label_set_long_mode(ssid_lbl, LV_LABEL_LONG_DOT);
         lv_obj_set_width(ssid_lbl, 150);
+        /* LV_LABEL_LONG_DOT only ellipsises when the height is bounded too.
+         * Left at LV_SIZE_CONTENT the label grows instead, wrapping a long
+         * SSID onto a second line that the 38 px row then clips. Pin it to a
+         * single line so the text is truncated horizontally as intended. */
+        lv_obj_set_height(ssid_lbl, lv_font_get_line_height(&ui_font_name_14));
         lv_label_set_text(ssid_lbl, aps[i].ssid);
         lv_obj_set_style_text_color(ssid_lbl, lv_color_hex(0xFFFFFF), 0);
         lv_obj_set_style_text_font(ssid_lbl, &ui_font_name_14, 0);


### PR DESCRIPTION
The WLAN Setup list builds each access point as a 38 px row holding a SSID label (`ui_wifi.c`):

```c
lv_label_set_long_mode(ssid_lbl, LV_LABEL_LONG_DOT);
lv_obj_set_width(ssid_lbl, 150);
```

The intent is clear — truncate with an ellipsis at 150 px — but `LV_LABEL_LONG_DOT` only ellipsises when the **height** is bounded as well. Left at `LV_SIZE_CONTENT`, the label grows instead: a long SSID wraps onto a second line, two 16 px lines fill the whole 38 px row, and the text collides with its neighbours and gets clipped by the list.

## The fix

Pin the label to one line height, so the long mode truncates horizontally as intended:

```c
lv_obj_set_height(ssid_lbl, lv_font_get_line_height(&ui_font_name_14));
```

## Not a duplicate of #28

#28 fixes the marquee overflow of the WiFi status card on the **Settings** screen, and the `Connect` label alignment. This one is about the access point rows in the WLAN list. The two do not touch the same code.

## Verified

Reproduced and fixed in the desktop simulator from #31, whose WiFi stub deliberately advertises an over-long SSID. Before, it wrapped onto two lines and was clipped; after, it renders as `un-ssid-volontairement…` on a single line with the row intact. Reproducible with `./sim/build/meowkit-sim --screen wifi` once that PR lands.
