### PR TITLE
Make the PC Monitor gradient bars follow the values they sit next to

### DIFF
--- a/src/app/app_05/asset/ui.h
+++ b/src/app/app_05/asset/ui.h
@@ -35,6 +35,9 @@ LV_IMG_DECLARE(ui_img_temp2_full_png);    // assets/temp2_full.png
 
 // SCREEN: ui_PC_Monitor
 void ui_PC_Monitor_screen_init(void);
+/* Pilote les quatre jauges horizontales. Températures en °C, charges en %. */
+void ui_pc_monitor_set_gauges(int cpu_temp_c, int cpu_load_pct,
+                              int gpu_temp_c, int gpu_load_pct);
 void ui_pc_monitor_init(void); // optional helper to init and load screen
 
 // Widgets

--- a/src/app/app_05/asset/ui_PC_Monitor.c
+++ b/src/app/app_05/asset/ui_PC_Monitor.c
@@ -20,21 +20,31 @@ void ui_PC_Monitor_screen_init(void)
 
     ui_temp1 = lv_img_create(ui_PC_Monitor);
     lv_img_set_src(ui_temp1, &ui_img_temp1_full_png);
+    /* Découper l'image au lieu de la mettre à l'échelle : c'est ce qui
+     * permet de n'en révéler qu'une fraction, façon jauge. */
+    lv_img_set_size_mode(ui_temp1, LV_IMG_SIZE_MODE_REAL);
     lv_obj_set_width(ui_temp1, LV_SIZE_CONTENT);   /// 100
     lv_obj_set_height(ui_temp1, LV_SIZE_CONTENT);    /// 20
-    lv_obj_set_x(ui_temp1, -85);
+    lv_obj_set_x(ui_temp1, 25);
     lv_obj_set_y(ui_temp1, -10);
-    lv_obj_set_align(ui_temp1, LV_ALIGN_CENTER);
+    /* Ancré à gauche : la barre se vide par la droite quand sa largeur
+     * diminue, au lieu de rétrécir symétriquement. */
+    lv_obj_set_align(ui_temp1, LV_ALIGN_LEFT_MID);
     lv_obj_add_flag(ui_temp1, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_temp1, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
     ui_temp2 = lv_img_create(ui_PC_Monitor);
     lv_img_set_src(ui_temp2, &ui_img_temp1_full_png);
+    /* Découper l'image au lieu de la mettre à l'échelle : c'est ce qui
+     * permet de n'en révéler qu'une fraction, façon jauge. */
+    lv_img_set_size_mode(ui_temp2, LV_IMG_SIZE_MODE_REAL);
     lv_obj_set_width(ui_temp2, LV_SIZE_CONTENT);   /// 100
     lv_obj_set_height(ui_temp2, LV_SIZE_CONTENT);    /// 20
-    lv_obj_set_x(ui_temp2, -85);
+    lv_obj_set_x(ui_temp2, 25);
     lv_obj_set_y(ui_temp2, -40);
-    lv_obj_set_align(ui_temp2, LV_ALIGN_CENTER);
+    /* Ancré à gauche : la barre se vide par la droite quand sa largeur
+     * diminue, au lieu de rétrécir symétriquement. */
+    lv_obj_set_align(ui_temp2, LV_ALIGN_LEFT_MID);
     lv_obj_add_flag(ui_temp2, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_temp2, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
@@ -106,21 +116,31 @@ void ui_PC_Monitor_screen_init(void)
 
     ui_temp3 = lv_img_create(ui_PC_Monitor);
     lv_img_set_src(ui_temp3, &ui_img_temp1_full_png);
+    /* Découper l'image au lieu de la mettre à l'échelle : c'est ce qui
+     * permet de n'en révéler qu'une fraction, façon jauge. */
+    lv_img_set_size_mode(ui_temp3, LV_IMG_SIZE_MODE_REAL);
     lv_obj_set_width(ui_temp3, LV_SIZE_CONTENT);   /// 100
     lv_obj_set_height(ui_temp3, LV_SIZE_CONTENT);    /// 20
-    lv_obj_set_x(ui_temp3, 30);
+    lv_obj_set_x(ui_temp3, 140);
     lv_obj_set_y(ui_temp3, 60);
-    lv_obj_set_align(ui_temp3, LV_ALIGN_CENTER);
+    /* Ancré à gauche : la barre se vide par la droite quand sa largeur
+     * diminue, au lieu de rétrécir symétriquement. */
+    lv_obj_set_align(ui_temp3, LV_ALIGN_LEFT_MID);
     lv_obj_add_flag(ui_temp3, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_temp3, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
     ui_temp4 = lv_img_create(ui_PC_Monitor);
     lv_img_set_src(ui_temp4, &ui_img_temp1_full_png);
+    /* Découper l'image au lieu de la mettre à l'échelle : c'est ce qui
+     * permet de n'en révéler qu'une fraction, façon jauge. */
+    lv_img_set_size_mode(ui_temp4, LV_IMG_SIZE_MODE_REAL);
     lv_obj_set_width(ui_temp4, LV_SIZE_CONTENT);   /// 100
     lv_obj_set_height(ui_temp4, LV_SIZE_CONTENT);    /// 20
-    lv_obj_set_x(ui_temp4, 30);
+    lv_obj_set_x(ui_temp4, 140);
     lv_obj_set_y(ui_temp4, 90);
-    lv_obj_set_align(ui_temp4, LV_ALIGN_CENTER);
+    /* Ancré à gauche : la barre se vide par la droite quand sa largeur
+     * diminue, au lieu de rétrécir symétriquement. */
+    lv_obj_set_align(ui_temp4, LV_ALIGN_LEFT_MID);
     lv_obj_add_flag(ui_temp4, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_temp4, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
@@ -214,3 +234,38 @@ void ui_PC_Monitor_screen_init(void)
 
 }
 
+
+/* ── Jauges ───────────────────────────────────────────────────────────
+ * Les cinq barres dégradées de cet écran étaient créées puis jamais
+ * touchées : elles affichaient le dégradé complet quel que soit l'état de
+ * la machine. Les quatre horizontales sont désormais pilotées.
+ * (ui_Image5, la barre verticale du bloc mémoire, est laissée telle quelle :
+ * son sens de remplissage et son ancrage demandent une décision de design.)
+ */
+#define GAUGE_W        100
+#define GAUGE_TEMP_MIN  30   /* °C — en dessous, barre vide */
+#define GAUGE_TEMP_MAX  90   /* °C — au-dessus, barre pleine */
+
+static void gauge_set(lv_obj_t * bar, int pct)
+{
+    if (!bar) return;
+    if (pct < 0)   pct = 0;
+    if (pct > 100) pct = 100;
+    lv_obj_set_width(bar, (GAUGE_W * pct) / 100);
+}
+
+static int gauge_temp_pct(int celsius)
+{
+    if (celsius <= GAUGE_TEMP_MIN) return 0;
+    if (celsius >= GAUGE_TEMP_MAX) return 100;
+    return ((celsius - GAUGE_TEMP_MIN) * 100) / (GAUGE_TEMP_MAX - GAUGE_TEMP_MIN);
+}
+
+void ui_pc_monitor_set_gauges(int cpu_temp_c, int cpu_load_pct,
+                              int gpu_temp_c, int gpu_load_pct)
+{
+    gauge_set(ui_temp2, gauge_temp_pct(cpu_temp_c));   /* température CPU */
+    gauge_set(ui_temp1, cpu_load_pct);                 /* charge CPU      */
+    gauge_set(ui_temp3, gauge_temp_pct(gpu_temp_c));   /* température GPU */
+    gauge_set(ui_temp4, gpu_load_pct);                 /* charge GPU      */
+}

--- a/src/app/app_05/pc_monitor.cpp
+++ b/src/app/app_05/pc_monitor.cpp
@@ -83,6 +83,11 @@ void style_01(DEVICES* _device) {
     /*GPU LOAD*/
     lv_label_set_text(ui_gpu_percent, gpuString2.c_str());
 
+    /* Les quatre barres dégradées suivent désormais les valeurs affichées ;
+     * elles montraient jusqu'ici le dégradé complet en permanence. */
+    ui_pc_monitor_set_gauges(cpuString1.toInt(), cpuString2.toInt(),
+                             gpuString1.toInt(), gpuString2.toInt());
+
   //----------------------------------------SYSTEM  RAM TOTAL---------------------------------------------------//
   /*SYSTEM RAM String*/
   int ramStringStart = inputString.indexOf("R", gpuStringLimit);


### PR DESCRIPTION
The PC Monitor screen draws five gradient bars beside its readings. All five are created in `ui_PC_Monitor.c` and then never touched again — `pc_monitor.cpp` updates eight labels and holds no reference to any bar. They therefore show the full green-to-red gradient permanently, whatever the machine is doing.

That reads as a broken gauge rather than as decoration, and the asset name gives the intent away: `ui_img_temp1_full_png` implies a partial state was meant to exist.

This PR drives the four horizontal bars. The vertical one is handled separately in the memory-block PR.

## What each bar measures

Their positions pair them unambiguously with the value beside them:

| Bar | y | Value | y |
|---|---|---|---|
| `ui_temp2` | −40 | `ui_cpu_temp` | −40 |
| `ui_temp1` | −10 | `ui_cpu_percent` | −10 |
| `ui_temp3` | 60 | `ui_gpu_temp` | 60 |
| `ui_temp4` | 90 | `ui_gpu_percent` | 90 |

## How

- `LV_IMG_SIZE_MODE_REAL` so the image is clipped rather than scaled — that is what lets a fraction of it be revealed.
- Re-anchoring to `LV_ALIGN_LEFT_MID`, with x recomputed from the previous centre position (`160 + x − 50`). Without this, reducing the width would shrink the bar towards its centre instead of emptying it from the right.
- `ui_pc_monitor_set_gauges()`, called from `pc_monitor.cpp` with the values it has just parsed.

## The one judgement call

Temperatures map to **30–90 °C**; loads are used as-is. Those bounds are a proposal, not a measurement — they are the two constants a reviewer is most likely to want to change, so they are named `GAUGE_TEMP_MIN` / `GAUGE_TEMP_MAX` rather than buried.

## Verified

Rendered in the desktop simulator (#31). At full width the output is **pixel-identical** to before — `compare -metric AE` reports 0 — which is what confirms the re-anchoring is exact rather than merely close. With values driven in, the four bars fill proportionally.

Also flashed to a production MeowKit-S3 and watched under load: the bars track real CPU and GPU activity.
