### PR TITLE
Colour each PC Monitor value like the bar beside it

### DIFF
--- a/src/app/app_05/asset/ui.h
+++ b/src/app/app_05/asset/ui.h
@@ -35,6 +35,9 @@ LV_IMG_DECLARE(ui_img_temp2_full_png);    // assets/temp2_full.png
 
 // SCREEN: ui_PC_Monitor
 void ui_PC_Monitor_screen_init(void);
+/* Pilote les quatre jauges horizontales. Températures en °C, charges en %. */
+void ui_pc_monitor_set_gauges(int cpu_temp_c, int cpu_load_pct,
+                              int gpu_temp_c, int gpu_load_pct);
 void ui_pc_monitor_init(void); // optional helper to init and load screen
 
 // Widgets

--- a/src/app/app_05/asset/ui_PC_Monitor.c
+++ b/src/app/app_05/asset/ui_PC_Monitor.c
@@ -246,6 +246,27 @@ void ui_PC_Monitor_screen_init(void)
 #define GAUGE_TEMP_MIN  30   /* °C — en dessous, barre vide */
 #define GAUGE_TEMP_MAX  90   /* °C — au-dessus, barre pleine */
 
+/* Le dégradé des barres n'est pas continu : c'est quatre bandes franches,
+ * relevées directement sur l'image. Le chiffre prend la couleur de la bande où
+ * tombe sa valeur, il s'accorde donc exactement avec la barre à côté de lui.
+ * L'écran WiFi emploie déjà ce procédé pour son pourcentage de signal. */
+static lv_color_t gauge_color(int pct)
+{
+    if (pct < 40) return lv_color_hex(0xBDE700);   /* vert lime */
+    if (pct < 60) return lv_color_hex(0xEFDF29);   /* jaune     */
+    if (pct < 80) return lv_color_hex(0xF78629);   /* orange    */
+    return lv_color_hex(0xF75129);                 /* rouge     */
+}
+
+static void value_set_color(lv_obj_t * label, int pct)
+{
+    if (!label) return;
+    if (pct < 0)   pct = 0;
+    if (pct > 100) pct = 100;
+    lv_obj_set_style_text_color(label, gauge_color(pct),
+                                LV_PART_MAIN | LV_STATE_DEFAULT);
+}
+
 static void gauge_set(lv_obj_t * bar, int pct)
 {
     if (!bar) return;
@@ -264,8 +285,17 @@ static int gauge_temp_pct(int celsius)
 void ui_pc_monitor_set_gauges(int cpu_temp_c, int cpu_load_pct,
                               int gpu_temp_c, int gpu_load_pct)
 {
-    gauge_set(ui_temp2, gauge_temp_pct(cpu_temp_c));   /* température CPU */
+    int cpu_t_pct = gauge_temp_pct(cpu_temp_c);
+    int gpu_t_pct = gauge_temp_pct(gpu_temp_c);
+
+    gauge_set(ui_temp2, cpu_t_pct);                    /* température CPU */
     gauge_set(ui_temp1, cpu_load_pct);                 /* charge CPU      */
-    gauge_set(ui_temp3, gauge_temp_pct(gpu_temp_c));   /* température GPU */
+    gauge_set(ui_temp3, gpu_t_pct);                    /* température GPU */
     gauge_set(ui_temp4, gpu_load_pct);                 /* charge GPU      */
+
+    /* Le chiffre suit la couleur de sa barre, au lieu d'un vert lime figé. */
+    value_set_color(ui_cpu_temp,    cpu_t_pct);
+    value_set_color(ui_cpu_percent, cpu_load_pct);
+    value_set_color(ui_gpu_temp,    gpu_t_pct);
+    value_set_color(ui_gpu_percent, gpu_load_pct);
 }

--- a/src/app/app_05/asset/ui_PC_Monitor.c
+++ b/src/app/app_05/asset/ui_PC_Monitor.c
@@ -20,21 +20,31 @@ void ui_PC_Monitor_screen_init(void)
 
     ui_temp1 = lv_img_create(ui_PC_Monitor);
     lv_img_set_src(ui_temp1, &ui_img_temp1_full_png);
+    /* Découper l'image au lieu de la mettre à l'échelle : c'est ce qui
+     * permet de n'en révéler qu'une fraction, façon jauge. */
+    lv_img_set_size_mode(ui_temp1, LV_IMG_SIZE_MODE_REAL);
     lv_obj_set_width(ui_temp1, LV_SIZE_CONTENT);   /// 100
     lv_obj_set_height(ui_temp1, LV_SIZE_CONTENT);    /// 20
-    lv_obj_set_x(ui_temp1, -85);
+    lv_obj_set_x(ui_temp1, 25);
     lv_obj_set_y(ui_temp1, -10);
-    lv_obj_set_align(ui_temp1, LV_ALIGN_CENTER);
+    /* Ancré à gauche : la barre se vide par la droite quand sa largeur
+     * diminue, au lieu de rétrécir symétriquement. */
+    lv_obj_set_align(ui_temp1, LV_ALIGN_LEFT_MID);
     lv_obj_add_flag(ui_temp1, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_temp1, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
     ui_temp2 = lv_img_create(ui_PC_Monitor);
     lv_img_set_src(ui_temp2, &ui_img_temp1_full_png);
+    /* Découper l'image au lieu de la mettre à l'échelle : c'est ce qui
+     * permet de n'en révéler qu'une fraction, façon jauge. */
+    lv_img_set_size_mode(ui_temp2, LV_IMG_SIZE_MODE_REAL);
     lv_obj_set_width(ui_temp2, LV_SIZE_CONTENT);   /// 100
     lv_obj_set_height(ui_temp2, LV_SIZE_CONTENT);    /// 20
-    lv_obj_set_x(ui_temp2, -85);
+    lv_obj_set_x(ui_temp2, 25);
     lv_obj_set_y(ui_temp2, -40);
-    lv_obj_set_align(ui_temp2, LV_ALIGN_CENTER);
+    /* Ancré à gauche : la barre se vide par la droite quand sa largeur
+     * diminue, au lieu de rétrécir symétriquement. */
+    lv_obj_set_align(ui_temp2, LV_ALIGN_LEFT_MID);
     lv_obj_add_flag(ui_temp2, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_temp2, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
@@ -106,21 +116,31 @@ void ui_PC_Monitor_screen_init(void)
 
     ui_temp3 = lv_img_create(ui_PC_Monitor);
     lv_img_set_src(ui_temp3, &ui_img_temp1_full_png);
+    /* Découper l'image au lieu de la mettre à l'échelle : c'est ce qui
+     * permet de n'en révéler qu'une fraction, façon jauge. */
+    lv_img_set_size_mode(ui_temp3, LV_IMG_SIZE_MODE_REAL);
     lv_obj_set_width(ui_temp3, LV_SIZE_CONTENT);   /// 100
     lv_obj_set_height(ui_temp3, LV_SIZE_CONTENT);    /// 20
-    lv_obj_set_x(ui_temp3, 30);
+    lv_obj_set_x(ui_temp3, 140);
     lv_obj_set_y(ui_temp3, 60);
-    lv_obj_set_align(ui_temp3, LV_ALIGN_CENTER);
+    /* Ancré à gauche : la barre se vide par la droite quand sa largeur
+     * diminue, au lieu de rétrécir symétriquement. */
+    lv_obj_set_align(ui_temp3, LV_ALIGN_LEFT_MID);
     lv_obj_add_flag(ui_temp3, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_temp3, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
     ui_temp4 = lv_img_create(ui_PC_Monitor);
     lv_img_set_src(ui_temp4, &ui_img_temp1_full_png);
+    /* Découper l'image au lieu de la mettre à l'échelle : c'est ce qui
+     * permet de n'en révéler qu'une fraction, façon jauge. */
+    lv_img_set_size_mode(ui_temp4, LV_IMG_SIZE_MODE_REAL);
     lv_obj_set_width(ui_temp4, LV_SIZE_CONTENT);   /// 100
     lv_obj_set_height(ui_temp4, LV_SIZE_CONTENT);    /// 20
-    lv_obj_set_x(ui_temp4, 30);
+    lv_obj_set_x(ui_temp4, 140);
     lv_obj_set_y(ui_temp4, 90);
-    lv_obj_set_align(ui_temp4, LV_ALIGN_CENTER);
+    /* Ancré à gauche : la barre se vide par la droite quand sa largeur
+     * diminue, au lieu de rétrécir symétriquement. */
+    lv_obj_set_align(ui_temp4, LV_ALIGN_LEFT_MID);
     lv_obj_add_flag(ui_temp4, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_temp4, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
@@ -214,3 +234,38 @@ void ui_PC_Monitor_screen_init(void)
 
 }
 
+
+/* ── Jauges ───────────────────────────────────────────────────────────
+ * Les cinq barres dégradées de cet écran étaient créées puis jamais
+ * touchées : elles affichaient le dégradé complet quel que soit l'état de
+ * la machine. Les quatre horizontales sont désormais pilotées.
+ * (ui_Image5, la barre verticale du bloc mémoire, est laissée telle quelle :
+ * son sens de remplissage et son ancrage demandent une décision de design.)
+ */
+#define GAUGE_W        100
+#define GAUGE_TEMP_MIN  30   /* °C — en dessous, barre vide */
+#define GAUGE_TEMP_MAX  90   /* °C — au-dessus, barre pleine */
+
+static void gauge_set(lv_obj_t * bar, int pct)
+{
+    if (!bar) return;
+    if (pct < 0)   pct = 0;
+    if (pct > 100) pct = 100;
+    lv_obj_set_width(bar, (GAUGE_W * pct) / 100);
+}
+
+static int gauge_temp_pct(int celsius)
+{
+    if (celsius <= GAUGE_TEMP_MIN) return 0;
+    if (celsius >= GAUGE_TEMP_MAX) return 100;
+    return ((celsius - GAUGE_TEMP_MIN) * 100) / (GAUGE_TEMP_MAX - GAUGE_TEMP_MIN);
+}
+
+void ui_pc_monitor_set_gauges(int cpu_temp_c, int cpu_load_pct,
+                              int gpu_temp_c, int gpu_load_pct)
+{
+    gauge_set(ui_temp2, gauge_temp_pct(cpu_temp_c));   /* température CPU */
+    gauge_set(ui_temp1, cpu_load_pct);                 /* charge CPU      */
+    gauge_set(ui_temp3, gauge_temp_pct(gpu_temp_c));   /* température GPU */
+    gauge_set(ui_temp4, gpu_load_pct);                 /* charge GPU      */
+}

--- a/src/app/app_05/pc_monitor.cpp
+++ b/src/app/app_05/pc_monitor.cpp
@@ -83,6 +83,11 @@ void style_01(DEVICES* _device) {
     /*GPU LOAD*/
     lv_label_set_text(ui_gpu_percent, gpuString2.c_str());
 
+    /* Les quatre barres dégradées suivent désormais les valeurs affichées ;
+     * elles montraient jusqu'ici le dégradé complet en permanence. */
+    ui_pc_monitor_set_gauges(cpuString1.toInt(), cpuString2.toInt(),
+                             gpuString1.toInt(), gpuString2.toInt());
+
   //----------------------------------------SYSTEM  RAM TOTAL---------------------------------------------------//
   /*SYSTEM RAM String*/
   int ramStringStart = inputString.indexOf("R", gpuStringLimit);


### PR DESCRIPTION
Builds on #37 — that PR must land first; the two share the band thresholds.

The four readings are drawn in a fixed lime (`0xA3DE00`) regardless of what they say, so a CPU at 90 °C looks exactly as calm as one at 30 °C. The gradient bar beside each of them already carries that information; the number does not.

## Where the colours come from

Sampling the bar image shows the gradient is not continuous but four flat bands:

| Range | Colour |
|---|---|
| < 40 % | `#BDE700` lime |
| 40–59 % | `#EFDF29` yellow |
| 60–79 % | `#F78629` orange |
| ≥ 80 % | `#F75129` red |

So the value takes the exact colour of the band it falls in — no interpolation, no invented palette. The number and its bar always agree, because they read from the same source.

## Precedent

This is not a new idiom for the firmware: `ui_wifi.c` already colours the signal percentage by value (≥70 % green, 40–69 % white, <40 % grey). Note the polarity is opposite there — a high number is good — so here the colours follow the bar rather than that screen.

## Judgement call

Whether load should be coloured at all is arguable: a CPU pinned at 100 % is working, not failing, whereas 90 °C is genuinely hot. It is coloured here for consistency with its bar, which already reddens. Easy to restrict to temperatures if you would rather.

## Verified

Swept across four regimes in the desktop simulator (#31) — 35/25, 52/45, 68/62, 85/95 — and the numbers change band exactly where their bars do. Also confirmed on a flashed device under load.
