### PR TITLE
Clear the PC Monitor screen when the host stops sending

### DIFF
--- a/src/app/app_05/asset/ui.h
+++ b/src/app/app_05/asset/ui.h
@@ -35,6 +35,9 @@ LV_IMG_DECLARE(ui_img_temp2_full_png);    // assets/temp2_full.png
 
 // SCREEN: ui_PC_Monitor
 void ui_PC_Monitor_screen_init(void);
+/* Pilote les quatre jauges horizontales. Températures en °C, charges en %. */
+void ui_pc_monitor_set_gauges(int cpu_temp_c, int cpu_load_pct,
+                              int gpu_temp_c, int gpu_load_pct);
 void ui_pc_monitor_init(void); // optional helper to init and load screen
 
 // Widgets

--- a/src/app/app_05/asset/ui_PC_Monitor.c
+++ b/src/app/app_05/asset/ui_PC_Monitor.c
@@ -20,21 +20,31 @@ void ui_PC_Monitor_screen_init(void)
 
     ui_temp1 = lv_img_create(ui_PC_Monitor);
     lv_img_set_src(ui_temp1, &ui_img_temp1_full_png);
+    /* Découper l'image au lieu de la mettre à l'échelle : c'est ce qui
+     * permet de n'en révéler qu'une fraction, façon jauge. */
+    lv_img_set_size_mode(ui_temp1, LV_IMG_SIZE_MODE_REAL);
     lv_obj_set_width(ui_temp1, LV_SIZE_CONTENT);   /// 100
     lv_obj_set_height(ui_temp1, LV_SIZE_CONTENT);    /// 20
-    lv_obj_set_x(ui_temp1, -85);
+    lv_obj_set_x(ui_temp1, 25);
     lv_obj_set_y(ui_temp1, -10);
-    lv_obj_set_align(ui_temp1, LV_ALIGN_CENTER);
+    /* Ancré à gauche : la barre se vide par la droite quand sa largeur
+     * diminue, au lieu de rétrécir symétriquement. */
+    lv_obj_set_align(ui_temp1, LV_ALIGN_LEFT_MID);
     lv_obj_add_flag(ui_temp1, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_temp1, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
     ui_temp2 = lv_img_create(ui_PC_Monitor);
     lv_img_set_src(ui_temp2, &ui_img_temp1_full_png);
+    /* Découper l'image au lieu de la mettre à l'échelle : c'est ce qui
+     * permet de n'en révéler qu'une fraction, façon jauge. */
+    lv_img_set_size_mode(ui_temp2, LV_IMG_SIZE_MODE_REAL);
     lv_obj_set_width(ui_temp2, LV_SIZE_CONTENT);   /// 100
     lv_obj_set_height(ui_temp2, LV_SIZE_CONTENT);    /// 20
-    lv_obj_set_x(ui_temp2, -85);
+    lv_obj_set_x(ui_temp2, 25);
     lv_obj_set_y(ui_temp2, -40);
-    lv_obj_set_align(ui_temp2, LV_ALIGN_CENTER);
+    /* Ancré à gauche : la barre se vide par la droite quand sa largeur
+     * diminue, au lieu de rétrécir symétriquement. */
+    lv_obj_set_align(ui_temp2, LV_ALIGN_LEFT_MID);
     lv_obj_add_flag(ui_temp2, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_temp2, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
@@ -106,21 +116,31 @@ void ui_PC_Monitor_screen_init(void)
 
     ui_temp3 = lv_img_create(ui_PC_Monitor);
     lv_img_set_src(ui_temp3, &ui_img_temp1_full_png);
+    /* Découper l'image au lieu de la mettre à l'échelle : c'est ce qui
+     * permet de n'en révéler qu'une fraction, façon jauge. */
+    lv_img_set_size_mode(ui_temp3, LV_IMG_SIZE_MODE_REAL);
     lv_obj_set_width(ui_temp3, LV_SIZE_CONTENT);   /// 100
     lv_obj_set_height(ui_temp3, LV_SIZE_CONTENT);    /// 20
-    lv_obj_set_x(ui_temp3, 30);
+    lv_obj_set_x(ui_temp3, 140);
     lv_obj_set_y(ui_temp3, 60);
-    lv_obj_set_align(ui_temp3, LV_ALIGN_CENTER);
+    /* Ancré à gauche : la barre se vide par la droite quand sa largeur
+     * diminue, au lieu de rétrécir symétriquement. */
+    lv_obj_set_align(ui_temp3, LV_ALIGN_LEFT_MID);
     lv_obj_add_flag(ui_temp3, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_temp3, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
     ui_temp4 = lv_img_create(ui_PC_Monitor);
     lv_img_set_src(ui_temp4, &ui_img_temp1_full_png);
+    /* Découper l'image au lieu de la mettre à l'échelle : c'est ce qui
+     * permet de n'en révéler qu'une fraction, façon jauge. */
+    lv_img_set_size_mode(ui_temp4, LV_IMG_SIZE_MODE_REAL);
     lv_obj_set_width(ui_temp4, LV_SIZE_CONTENT);   /// 100
     lv_obj_set_height(ui_temp4, LV_SIZE_CONTENT);    /// 20
-    lv_obj_set_x(ui_temp4, 30);
+    lv_obj_set_x(ui_temp4, 140);
     lv_obj_set_y(ui_temp4, 90);
-    lv_obj_set_align(ui_temp4, LV_ALIGN_CENTER);
+    /* Ancré à gauche : la barre se vide par la droite quand sa largeur
+     * diminue, au lieu de rétrécir symétriquement. */
+    lv_obj_set_align(ui_temp4, LV_ALIGN_LEFT_MID);
     lv_obj_add_flag(ui_temp4, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_temp4, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
@@ -214,3 +234,38 @@ void ui_PC_Monitor_screen_init(void)
 
 }
 
+
+/* ── Jauges ───────────────────────────────────────────────────────────
+ * Les cinq barres dégradées de cet écran étaient créées puis jamais
+ * touchées : elles affichaient le dégradé complet quel que soit l'état de
+ * la machine. Les quatre horizontales sont désormais pilotées.
+ * (ui_Image5, la barre verticale du bloc mémoire, est laissée telle quelle :
+ * son sens de remplissage et son ancrage demandent une décision de design.)
+ */
+#define GAUGE_W        100
+#define GAUGE_TEMP_MIN  30   /* °C — en dessous, barre vide */
+#define GAUGE_TEMP_MAX  90   /* °C — au-dessus, barre pleine */
+
+static void gauge_set(lv_obj_t * bar, int pct)
+{
+    if (!bar) return;
+    if (pct < 0)   pct = 0;
+    if (pct > 100) pct = 100;
+    lv_obj_set_width(bar, (GAUGE_W * pct) / 100);
+}
+
+static int gauge_temp_pct(int celsius)
+{
+    if (celsius <= GAUGE_TEMP_MIN) return 0;
+    if (celsius >= GAUGE_TEMP_MAX) return 100;
+    return ((celsius - GAUGE_TEMP_MIN) * 100) / (GAUGE_TEMP_MAX - GAUGE_TEMP_MIN);
+}
+
+void ui_pc_monitor_set_gauges(int cpu_temp_c, int cpu_load_pct,
+                              int gpu_temp_c, int gpu_load_pct)
+{
+    gauge_set(ui_temp2, gauge_temp_pct(cpu_temp_c));   /* température CPU */
+    gauge_set(ui_temp1, cpu_load_pct);                 /* charge CPU      */
+    gauge_set(ui_temp3, gauge_temp_pct(gpu_temp_c));   /* température GPU */
+    gauge_set(ui_temp4, gpu_load_pct);                 /* charge GPU      */
+}

--- a/src/app/app_05/pc_monitor.cpp
+++ b/src/app/app_05/pc_monitor.cpp
@@ -83,6 +83,11 @@ void style_01(DEVICES* _device) {
     /*GPU LOAD*/
     lv_label_set_text(ui_gpu_percent, gpuString2.c_str());
 
+    /* Les quatre barres dégradées suivent désormais les valeurs affichées ;
+     * elles montraient jusqu'ici le dégradé complet en permanence. */
+    ui_pc_monitor_set_gauges(cpuString1.toInt(), cpuString2.toInt(),
+                             gpuString1.toInt(), gpuString2.toInt());
+
   //----------------------------------------SYSTEM  RAM TOTAL---------------------------------------------------//
   /*SYSTEM RAM String*/
   int ramStringStart = inputString.indexOf("R", gpuStringLimit);

--- a/src/app/app_05/pc_monitor.cpp
+++ b/src/app/app_05/pc_monitor.cpp
@@ -18,6 +18,12 @@ String inputString = "";
 bool stringComplete = false;
 const int Serial0_eventDelay = 15;
 static bool s_hasData = false; // The value will not be displayed until the first complete frame of data is received.
+static uint32_t s_lastFrameMs = 0; // Date de la dernière trame complète reçue.
+
+/* L'hôte émet une trame par seconde. Au-delà de ce délai sans rien recevoir, on
+ * considère qu'il n'y a plus personne : câble débranché, service arrêté, PC
+ * éteint. Trois secondes tolèrent une trame manquée sans clignoter. */
+#define PCMON_STALE_MS 3000
 
 void style_01(DEVICES* _device) {
     //------------------------------------------- Update UI widgets (LVGL) ----------------------------------------------------//
@@ -150,6 +156,23 @@ void style_01(DEVICES* _device) {
 }
 
 
+/* Remet l'écran à l'état « aucune donnée » : libellés vides et jauges à zéro.
+ * Un libellé vide dit « rien à afficher » ; un « 0 » affirmerait une mesure,
+ * ce qui serait faux — un CPU n'est pas à 0 °C parce que le câble est débranché. */
+static void pc_monitor_blank()
+{
+    lv_label_set_text(ui_cpu_name, "");
+    lv_label_set_text(ui_gpu_name, "");
+    lv_label_set_text(ui_cpu_temp, "");
+    lv_label_set_text(ui_cpu_percent, "");
+    lv_label_set_text(ui_gpu_temp, "");
+    lv_label_set_text(ui_gpu_percent, "");
+    lv_label_set_text(ui_RAM, "");
+    lv_label_set_text(ui_mhz, "");
+    lv_label_set_text(ui_gpu_ram, "");
+    ui_pc_monitor_set_gauges(0, 0, 0, 0);
+}
+
 namespace MOONCAKE::APPS
 {
     PCMonitor::PCMonitor(DEVICES* device)
@@ -167,22 +190,7 @@ namespace MOONCAKE::APPS
         // Loading the LVGL interface (two fonts, three images)
         ui_pc_monitor_init();
 
-        // Clear all numerical display when entering for the first time to avoid displaying old values ​​or placeholder text
-        // CPU/GPU name
-        lv_label_set_text(ui_cpu_name, "");
-        lv_label_set_text(ui_gpu_name, "");
-        // CPU temperature/occupancy
-        lv_label_set_text(ui_cpu_temp, "");
-        lv_label_set_text(ui_cpu_percent, "");
-        // GPU temperature/occupancy
-        lv_label_set_text(ui_gpu_temp, "");
-        lv_label_set_text(ui_gpu_percent, "");
-        // RAM used/total
-        lv_label_set_text(ui_RAM, "");
-        // CPU frequency
-        lv_label_set_text(ui_mhz, "");
-        // Total video memory
-        lv_label_set_text(ui_gpu_ram, "");
+        pc_monitor_blank();
     }
 
     void PCMonitor::onRunning()
@@ -199,9 +207,16 @@ namespace MOONCAKE::APPS
 
         if (stringComplete) {
             s_hasData = true; // Receive the first complete frame of data
+            s_lastFrameMs = millis();
             style_01(_device);
             inputString = "";
             stringComplete = false;
+        }
+        else if (s_hasData && (millis() - s_lastFrameMs) > PCMON_STALE_MS) {
+            /* Plus rien n'arrive : effacer plutôt que laisser des valeurs
+             * périmées, qui ont l'apparence de mesures vivantes. */
+            s_hasData = false;
+            pc_monitor_blank();
         }
         // Let LVGL process tasks to refresh the screen
         lv_timer_handler();


### PR DESCRIPTION
Builds on #37 — that PR must land first; the blanking helper zeroes the gauges it introduces.

Once a frame has been received, the values stay on screen for ever. Unplug the cable, stop the feeding program, or shut the computer down, and the readings freeze at their last value — indistinguishable from live data, which is worse than showing nothing at all.

## How

A frame now stamps `millis()`, and `onRunning()` blanks the screen after three seconds without one. The host sends one frame per second, so that tolerates a missed frame without flickering. The unsigned subtraction is `millis()`-rollover safe.

The clearing code that `onOpen()` already had is factored into `pc_monitor_blank()` and reused, so the two paths cannot drift apart.

## Empty rather than zero

It empties the labels rather than writing zeroes. An empty label says *nothing to show*; a `0` would assert a measurement, and a CPU is not at 0 °C because a cable came out. That also matches what `onOpen()` already did before any frame arrives, so the screen looks the same whether data has not started yet or has stopped.

## Verification status

Compiles, and the logic is small enough to read, but **this one is not yet verified on hardware** — the timeout is a timing behaviour that the desktop simulator cannot exercise, since the simulator does not run the app's serial loop. I will flash it and confirm that unplugging clears the screen after ~3 s and that replugging repopulates it.

Flagging that explicitly rather than letting the other PRs in this series imply it.