### PR TITLE
Make the Factory Reset dialog readable

### DIFF
--- a/src/ui/screens/ui_tabview.c
+++ b/src/ui/screens/ui_tabview.c
@@ -150,6 +150,10 @@ static void tab_factory_reset_cb(lv_event_t * e)
     lv_obj_set_style_bg_color(mbox,    lv_color_hex(TV_CARD),  LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_border_color(mbox, lv_color_hex(TV_DANGER), LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_border_width(mbox, 2,                      LV_PART_MAIN | LV_STATE_DEFAULT);
+    /* Sans ceci, titre et message héritent du gris sombre du thème par défaut,
+     * illisible sur le fond TV_CARD : seuls les boutons ressortaient. Les
+     * propriétés de texte étant héritées, la régler sur la boîte suffit. */
+    lv_obj_set_style_text_color(mbox, lv_color_hex(TV_TEXT), LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_center(mbox);
     lv_obj_add_event_cb(mbox, _fr_msgbox_cb, LV_EVENT_VALUE_CHANGED, NULL);
 }


### PR DESCRIPTION
`lv_msgbox_create()` leaves its title and body at the theme's default text colour, which is dark grey. On the near-black `TV_CARD` background these dialogs use, the buttons show and **the text does not**.

The Factory Reset dialog is the one that matters: the user is asked to confirm an irreversible erase without being able to read the question. Only `Reset` and `Cancel` are legible.

Text properties are inherited by children, so setting the colour on the msgbox itself reaches the title and body labels — one line.

Verified in the desktop simulator (#31), before and after.
