### PR TITLE
Fix IR replay bug

### DIFF
--- a/src/app/app_09/infrared.cpp
+++ b/src/app/app_09/infrared.cpp
@@ -1514,6 +1514,11 @@ namespace MOONCAKE::APPS
         } else {
             f.println("type: parsed");
             f.printf("protocol: %s\n", typeToFlipperProto(sig.protocol));
+            /* Preserve the exact decoder value used by IRremoteESP8266.
+             * Flipper's address/command fields are not sufficient to
+             * reconstruct it for every protocol. */
+            f.printf("value: 0x%llX\n", sig.value);
+            f.printf("bits: %u\n", sig.bits);
 
             char addrBuf[32], cmdBuf[32];
             int nbytes = (sig.bits + 7) / 8;
@@ -1561,6 +1566,7 @@ namespace MOONCAKE::APPS
         IrSignal sig;
         resetSig(sig);
         bool inSignal = false;
+        bool hasSerializedValue = false;
         String line;
 
         while (f.available()) {
@@ -1579,6 +1585,7 @@ namespace MOONCAKE::APPS
                     }
                 }
                 resetSig(sig);
+                hasSerializedValue = false;
                 strncpy(sig.name, line.c_str() + 6, sizeof(sig.name) - 1);
                 sig.name[sizeof(sig.name) - 1] = '\0';
                 inSignal = true;
@@ -1593,12 +1600,19 @@ namespace MOONCAKE::APPS
                 proto.trim();
                 sig.protocol = flipperProtoToType(proto.c_str());
             }
+            else if (line.startsWith("value: ")) {
+                sig.value = strtoull(line.c_str() + 7, nullptr, 0);
+                hasSerializedValue = true;
+            }
+            else if (line.startsWith("bits: ")) {
+                sig.bits = line.substring(6).toInt();
+            }
             else if (line.startsWith("address: ")) {
                 sig.address = parseHexBytes(line.c_str() + 9);
             }
             else if (line.startsWith("command: ")) {
                 sig.command = parseHexBytes(line.c_str() + 9);
-                if (!sig.isRaw) {
+                if (!sig.isRaw && !hasSerializedValue) {
                     sig.bits = 32;
                     sig.value = ((uint64_t)sig.address) | ((uint64_t)sig.command << 16);
                 }

--- a/src/app/app_09/infrared.cpp
+++ b/src/app/app_09/infrared.cpp
@@ -1517,8 +1517,8 @@ namespace MOONCAKE::APPS
             /* Preserve the exact decoder value used by IRremoteESP8266.
              * Flipper's address/command fields are not sufficient to
              * reconstruct it for every protocol. */
-            f.printf("value: 0x%llX\n", sig.value);
-            f.printf("bits: %u\n", sig.bits);
+            f.printf("value: 0x%llX\n", (unsigned long long)sig.value);
+            f.printf("bits: %u\n", (unsigned)sig.bits);
 
             char addrBuf[32], cmdBuf[32];
             int nbytes = (sig.bits + 7) / 8;
@@ -1567,6 +1567,7 @@ namespace MOONCAKE::APPS
         resetSig(sig);
         bool inSignal = false;
         bool hasSerializedValue = false;
+        bool hasSerializedBits = false;
         String line;
 
         while (f.available()) {
@@ -1586,6 +1587,7 @@ namespace MOONCAKE::APPS
                 }
                 resetSig(sig);
                 hasSerializedValue = false;
+                hasSerializedBits = false;
                 strncpy(sig.name, line.c_str() + 6, sizeof(sig.name) - 1);
                 sig.name[sizeof(sig.name) - 1] = '\0';
                 inSignal = true;
@@ -1606,15 +1608,21 @@ namespace MOONCAKE::APPS
             }
             else if (line.startsWith("bits: ")) {
                 sig.bits = line.substring(6).toInt();
+                hasSerializedBits = true;
             }
             else if (line.startsWith("address: ")) {
                 sig.address = parseHexBytes(line.c_str() + 9);
             }
             else if (line.startsWith("command: ")) {
                 sig.command = parseHexBytes(line.c_str() + 9);
-                if (!sig.isRaw && !hasSerializedValue) {
-                    sig.bits = 32;
-                    sig.value = ((uint64_t)sig.address) | ((uint64_t)sig.command << 16);
+                if (!sig.isRaw) {
+                    /* Only reconstruct the fields that weren't serialized
+                     * directly — a file may carry a real "bits:" value
+                     * without a "value:" field (or vice versa), so each
+                     * fallback must be guarded independently to avoid
+                     * clobbering data that was actually round-tripped. */
+                    if (!hasSerializedBits) sig.bits = 32;
+                    if (!hasSerializedValue) sig.value = ((uint64_t)sig.address) | ((uint64_t)sig.command << 16);
                 }
             }
             else if (line.startsWith("frequency: ")) {


### PR DESCRIPTION
This pull request updates the infrared signal serialization and deserialization logic to better preserve the original IR signal data, especially for protocols where Flipper's address/command fields are insufficient. The main changes are focused on reading and writing the exact decoder value and bit count, and ensuring these are handled correctly during parsing.

**Serialization and Deserialization Improvements:**

* When writing parsed IR signals, the code now includes the exact `value` and `bits` fields in the output, ensuring that the original decoder value from IRremoteESP8266 is preserved and can be reconstructed accurately.
* When reading IR signals, the parser now recognizes and restores the `value` and `bits` fields, using them if present instead of reconstructing from address/command. This is tracked with a new `hasSerializedValue` flag to avoid overwriting the original value. [[1]](diffhunk://#diff-581f617cf3f78d6d087d395ac41331bed724b7bf0c2fcf3e1ee18d1b32c09540R1569) [[2]](diffhunk://#diff-581f617cf3f78d6d087d395ac41331bed724b7bf0c2fcf3e1ee18d1b32c09540R1603-R1615)
* The logic for reconstructing the `value` and `bits` from address/command is now conditional: it only runs if the signal is not raw and no serialized value was found, preventing accidental overwrites.
* The `hasSerializedValue` flag is reset when a new signal is started, preventing leakage between signals.